### PR TITLE
Add blank sidebar panel

### DIFF
--- a/custom_components/ypiha/__init__.py
+++ b/custom_components/ypiha/__init__.py
@@ -1,6 +1,35 @@
 """YPIHA integration for Home Assistant."""
 
-def setup(hass, config):
-    """Set up the YPIHA integration."""
-    return True
+from __future__ import annotations
 
+import os
+
+DOMAIN = "ypiha"
+_PANEL_URL_PATH = "/ypiha-panel"
+_PANEL_ID = "ypiha"
+
+
+async def async_setup(hass, config):
+    """Set up the YPIHA integration with a sidebar panel."""
+    panel_dir = os.path.join(os.path.dirname(__file__), "panel")
+
+    hass.http.register_static_path(
+        _PANEL_URL_PATH, panel_dir, cache_headers=False, allow_override=True
+    )
+
+    frontend = hass.components.frontend
+
+    if _PANEL_ID in frontend.panels:
+        frontend.async_remove_panel(_PANEL_ID)
+
+    frontend.async_register_built_in_panel(
+        component_name="iframe",
+        sidebar_title="YPIHA",
+        sidebar_icon="mdi:file-outline",
+        config={"url": f"{_PANEL_URL_PATH}/index.html"},
+        require_admin=False,
+        config_panel_domain=DOMAIN,
+        panel_id=_PANEL_ID,
+    )
+
+    return True

--- a/custom_components/ypiha/panel/index.html
+++ b/custom_components/ypiha/panel/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <title>YPIHA</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        background: #ffffff;
+      }
+    </style>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## Summary
- register a built-in iframe panel for the YPIHA integration and expose a static path for its resources
- add a minimal blank HTML page to display when the sidebar entry is opened

## Testing
- python -m compileall custom_components/ypiha

------
https://chatgpt.com/codex/tasks/task_e_68d5c73beb0c83329ae555d2f9c2cd6d