### PR TITLE
Allow simple space name entry in config flow

### DIFF
--- a/custom_components/presence_graph/translations/en.json
+++ b/custom_components/presence_graph/translations/en.json
@@ -12,7 +12,7 @@
         "title": "Spaces",
         "description": "Define the spaces monitored by the graph.",
         "data": {
-          "spaces": "Spaces JSON"
+          "spaces": "Spaces (JSON or names)"
         }
       },
       "links": {

--- a/custom_components/presence_graph/translations/fr.json
+++ b/custom_components/presence_graph/translations/fr.json
@@ -12,7 +12,7 @@
         "title": "Espaces",
         "description": "Définir les pièces surveillées par le graphe.",
         "data": {
-          "spaces": "Espaces (JSON)"
+          "spaces": "Espaces (JSON ou noms)"
         }
       },
       "links": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,12 +18,7 @@ def test_full_config_flow():
     form = asyncio.run(flow.async_step_user(None))
     assert form["type"] == "form"
     asyncio.run(flow.async_step_user({"title": "Maison"}))
-    spaces_payload = json.dumps(
-        [
-            {"name": "Salon", "id": "salon", "motion_entities": ["binary_sensor.salon"]},
-            {"name": "Cuisine", "id": "cuisine", "motion_entities": ["binary_sensor.cuisine"]},
-        ]
-    )
+    spaces_payload = "Salon\nCuisine"
     asyncio.run(flow.async_step_spaces({"spaces": spaces_payload}))
     links_payload = json.dumps(
         [
@@ -39,6 +34,7 @@ def test_full_config_flow():
     summary = asyncio.run(flow.async_step_summary({}))
     assert summary["type"] == "create_entry"
     assert len(summary["data"][CONF_SPACES]) == 2
+    assert summary["data"][CONF_SPACES][0]["id"] == "salon"
     assert len(summary["data"][CONF_LINKS]) == 1
 
 
@@ -54,3 +50,12 @@ def test_options_flow_update():
     result = asyncio.run(handler.async_step_init({"spaces": spaces, "links": links}))
     assert result["type"] == "create_entry"
     assert result["data"][CONF_SPACES][0]["id"] == "chambre"
+
+
+def test_parse_spaces_from_comma_separated_list():
+    from custom_components.presence_graph.config_flow import _parse_spaces
+
+    payload = "Salon, Cuisine, Bureau"
+    spaces = _parse_spaces(payload)
+    assert [space["name"] for space in spaces] == ["Salon", "Cuisine", "Bureau"]
+    assert [space["id"] for space in spaces] == ["salon", "cuisine", "bureau"]


### PR DESCRIPTION
## Summary
- allow the space configuration step to accept either JSON definitions or simple lists of names
- document the new input format in the English and French translations
- extend config flow tests to cover the name list parsing helper

## Testing
- pytest
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d5ee13e0c883328125c4662a916ac7